### PR TITLE
Add Saltglass Expanse hub and allow unlock start validation

### DIFF
--- a/tools/validate.py
+++ b/tools/validate.py
@@ -156,6 +156,7 @@ def validate_effect(
         "hp_delta",
         "teleport",
         "end_game",
+        "unlock_start",
     }:
         ctx.add(f"{context}: unsupported effect type '{effect_type}'.")
         return
@@ -164,6 +165,10 @@ def validate_effect(
         value = effect.get("value")
         if not is_non_empty_str(value):
             ctx.add(f"{context}: '{effect_type}' requires a non-empty string 'value'.")
+    elif effect_type == "unlock_start":
+        value = effect.get("value")
+        if not is_non_empty_str(value):
+            ctx.add(f"{context}: 'unlock_start' requires a non-empty string 'value'.")
     elif effect_type == "set_flag":
         flag = effect.get("flag")
         if not is_non_empty_str(flag):

--- a/world/world.json
+++ b/world/world.json
@@ -67,6 +67,15 @@
                 "Healer"
             ],
             "locked": true
+        },
+        {
+            "id": "shade_walker_outpost",
+            "title": "Shade-Walker Outpost",
+            "node": "saltglass_expanse",
+            "tags": [
+                "Cartographer",
+                "Tinkerer"
+            ]
         }
     ],
     "endings": {
@@ -1053,6 +1062,15 @@
                 {
                     "text": "Return to the concourse tiers.",
                     "target": "root_orrery_concourse"
+                },
+                {
+                    "text": "Trace the mirrored dunes route toward the Saltglass Expanse.",
+                    "condition": {
+                        "type": "flag_eq",
+                        "flag": "correction_tuned",
+                        "value": true
+                    },
+                    "target": "saltglass_expanse"
                 }
             ]
         },
@@ -1613,6 +1631,892 @@
                     "target": "startways_nexus"
                 }
             ]
+        },
+        "saltglass_expanse": {
+            "title": "Saltglass Expanse",
+            "text": "Mirrored dunes ripple around migrating glass-reefs while walking shade engines stride overhead, casting cool rivers of shadow.",
+            "choices": [
+                {
+                    "text": "(Cartographer) Align the mirrored dune ridges with the reef migration.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "saltglass_routes_plotted",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_glass_reef"
+                },
+                {
+                    "text": "Enter the walking shade engine's bazaar decks.",
+                    "target": "saltglass_shade_bazaar"
+                },
+                {
+                    "text": "(Sneaky) Ghost along the engine struts toward the southern obelisk.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Sneaky"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "south_scouted",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_obelisk_south"
+                },
+                {
+                    "text": "Follow the tuned root-paths back to the Caretaker Dais.",
+                    "target": "root_orrery_dais"
+                }
+            ]
+        },
+        "saltglass_shade_bazaar": {
+            "title": "Shade Engine Bazaar",
+            "text": "Canvas streets coil inside a walking shade engine; caravans barter under glass awnings while pistons thrum with migrating rhythm.",
+            "choices": [
+                {
+                    "text": "(Tinkerer) Recalibrate the cooling vanes to earn a shade key.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Tinkerer"
+                    },
+                    "effects": [
+                        {
+                            "type": "add_item",
+                            "value": "shade key"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "shade_key_owned",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_shade_workshop"
+                },
+                {
+                    "text": "Haul spare struts to the repair cradle.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "workshop_access",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_shade_workshop"
+                },
+                {
+                    "text": "(Cartographer) Trade dune coordinates for a map sliver.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "add_item",
+                            "value": "map sliver"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "bazaar_map_traded",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_dune_archive"
+                },
+                {
+                    "text": "(Sneaky) Shadow a Freehands runner toward the reef scouts.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Sneaky"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "reef_whispers",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_glass_reef"
+                },
+                {
+                    "text": "Step back out into the mirrored dunes.",
+                    "target": "saltglass_expanse"
+                }
+            ]
+        },
+        "saltglass_shade_workshop": {
+            "title": "Shade Engine Workshop",
+            "text": "Glass-lathes hum beside cooling cisterns as artisans tune shade vanes for the migrating caravans.",
+            "choices": [
+                {
+                    "text": "(Tinkerer) Assemble a color baffle from refractor scraps.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Tinkerer"
+                    },
+                    "effects": [
+                        {
+                            "type": "add_item",
+                            "value": "color baffle"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "color_baffle_forged",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_shade_workshop"
+                },
+                {
+                    "text": "(Sneaky) Pocket a map sliver from the shipping manifest.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Sneaky"
+                    },
+                    "effects": [
+                        {
+                            "type": "add_item",
+                            "value": "map sliver"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "manifest_raided",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_dune_archive"
+                },
+                {
+                    "text": "(Lumenar) Fuse the glass seams to steady the walking city.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Lumenar"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Prism Cartel",
+                            "value": 1
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "seams_fused",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_shade_bazaar"
+                },
+                {
+                    "text": "Ask the Glasswright mentor to review your latticework.",
+                    "target": "mentor_glasswright_intro"
+                },
+                {
+                    "text": "Return to the bazaar's central deck.",
+                    "target": "saltglass_shade_bazaar"
+                }
+            ]
+        },
+        "saltglass_glass_reef": {
+            "title": "Migratory Glass Reef",
+            "text": "Fractal ridges of living glass surge like a slow tide, caravan tents lashed to their mirrored spines beneath roaming shade engines.",
+            "choices": [
+                {
+                    "text": "(Cartographer) Plot the reef's migration by mirrored stars.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "reef_routes_traced",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_obelisk_north"
+                },
+                {
+                    "text": "(Lumenar) Pulse calming light to let caravans slip past.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Lumenar"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Freehands",
+                            "value": 1
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "reef_calm",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_carravan_council"
+                },
+                {
+                    "text": "(Sneaky) Slip along the reef's underside toward the southern obelisk.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Sneaky"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "reef_sneak",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_obelisk_south"
+                },
+                {
+                    "text": "Ride a tethered skiff back toward the shade engine.",
+                    "target": "saltglass_shade_bazaar"
+                }
+            ]
+        },
+        "saltglass_dune_archive": {
+            "title": "Mirrored Dune Archive",
+            "text": "Strata of polished sand scroll with glint-script, each dune facet storing routes for the wandering cities.",
+            "choices": [
+                {
+                    "text": "(Cartographer) Translate the mirrored scripts into a map sliver.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "add_item",
+                            "value": "map sliver"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "dune_archive_decoded",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_obelisk_east"
+                },
+                {
+                    "text": "(Lumenar) Diffuse the glare into a portable color baffle.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Lumenar"
+                    },
+                    "effects": [
+                        {
+                            "type": "add_item",
+                            "value": "color baffle"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "glare_diffused",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_expanse"
+                },
+                {
+                    "text": "Spend a map sliver to unlock the refractor walkway beneath the dunes.",
+                    "condition": {
+                        "type": "has_item",
+                        "value": "map sliver"
+                    },
+                    "effects": [
+                        {
+                            "type": "remove_item",
+                            "value": "map sliver"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "refractor_walkway_open",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_carravan_council"
+                },
+                {
+                    "text": "Retreat before the dunes shift again.",
+                    "target": "saltglass_expanse"
+                }
+            ]
+        },
+        "saltglass_carravan_council": {
+            "title": "Caravan Council of Moving Shade",
+            "text": "Delegates debate beneath walking engine ribs while mirrored charts flutter between tents of traveling glasswrights.",
+            "choices": [
+                {
+                    "text": "(Cartographer) Present layered map slivers to redirect the caravans.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "council_mapped",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_carravan_council"
+                },
+                {
+                    "text": "(Sneaky) Whisper to outriders to secure covert passage rights.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Sneaky"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Freehands",
+                            "value": 1
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "council_shadowed",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_carravan_council"
+                },
+                {
+                    "text": "(Lumenar) Drape the council with cooled shade to settle tempers.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Lumenar"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Prism Cartel",
+                            "value": 1
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "council_cooled",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_carravan_council"
+                },
+                {
+                    "text": "Set the treaty dais with your shade key.",
+                    "condition": {
+                        "type": "has_item",
+                        "value": "shade key"
+                    },
+                    "target": "saltglass_treaty_alignment"
+                },
+                {
+                    "text": "Carry your notes back to the shade bazaar.",
+                    "target": "saltglass_shade_bazaar"
+                }
+            ]
+        },
+        "saltglass_obelisk_north": {
+            "title": "Northern Glint Obelisk",
+            "text": "A mirrored spire pierces the dunes, refracting the shade engine's shadow into sweeping compass arcs.",
+            "choices": [
+                {
+                    "text": "(Cartographer) Chart the northern glint obelisk's reflection lilt.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "glint_obelisk_north_mapped",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_obelisk_north"
+                },
+                {
+                    "text": "(Tinkerer) Reseat the obelisk's hinge to redirect shade.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Tinkerer"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Prism Cartel",
+                            "value": 1
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "obelisk_north_tuned",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_glass_reef"
+                },
+                {
+                    "text": "Deploy a color baffle to signal the reef outriders.",
+                    "condition": {
+                        "type": "has_item",
+                        "value": "color baffle"
+                    },
+                    "effects": [
+                        {
+                            "type": "remove_item",
+                            "value": "color baffle"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "reef_signal_sent",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_glass_reef"
+                },
+                {
+                    "text": "Slide down the mirrored ridge back toward the dunes.",
+                    "target": "saltglass_expanse"
+                }
+            ]
+        },
+        "saltglass_obelisk_south": {
+            "title": "Southern Glint Obelisk",
+            "text": "Glass-reef barnacles cling to the southern obelisk, its beam sweeping migrating camps with restless color.",
+            "choices": [
+                {
+                    "text": "(Cartographer) Map the southern obelisk's moving shadows.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "glint_obelisk_south_mapped",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_obelisk_south"
+                },
+                {
+                    "text": "(Sneaky) Ride the reef's underside to stash a map sliver.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Sneaky"
+                    },
+                    "effects": [
+                        {
+                            "type": "add_item",
+                            "value": "map sliver"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "reef_cache",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_glass_reef"
+                },
+                {
+                    "text": "(Tinkerer) Stitch a color baffle lattice around the beam.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Tinkerer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "obelisk_south_latticed",
+                            "value": true
+                        },
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "saltglass_expanse"
+                },
+                {
+                    "text": "Follow the mirrored track back to the camp.",
+                    "target": "saltglass_expanse"
+                }
+            ]
+        },
+        "saltglass_obelisk_east": {
+            "title": "Eastern Glint Obelisk",
+            "text": "The eastern obelisk pivots above a sea of mirrored dunes, its beam catching distant shade engines in prismatic arcs.",
+            "choices": [
+                {
+                    "text": "(Cartographer) Align the eastern glint with your star chart.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "glint_obelisk_east_mapped",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_obelisk_east"
+                },
+                {
+                    "text": "(Lumenar) Bend the beam to reveal hidden camp caches.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Lumenar"
+                    },
+                    "effects": [
+                        {
+                            "type": "add_item",
+                            "value": "color baffle"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "east_cache_revealed",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_carravan_council"
+                },
+                {
+                    "text": "Take the mirrored steps back toward the dune archive.",
+                    "target": "saltglass_dune_archive"
+                },
+                {
+                    "text": "Thread the glint lines toward the northern obelisk.",
+                    "condition": {
+                        "type": "flag_eq",
+                        "flag": "glint_obelisk_east_mapped",
+                        "value": true
+                    },
+                    "target": "saltglass_glint_merge_ne"
+                }
+            ]
+        },
+        "saltglass_glint_merge_ne": {
+            "title": "Glint Alignment Confluence",
+            "text": "Northern and eastern beams overlap in a lattice of ghost-light, humming with routes waiting to be tied off.",
+            "choices": [
+                {
+                    "text": "(Cartographer) Weave in the northern glint pathways.",
+                    "condition": {
+                        "type": "flag_eq",
+                        "flag": "glint_obelisk_north_mapped",
+                        "value": true
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "glint_north_threaded",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_glint_merge_ring"
+                },
+                {
+                    "text": "Let the reflections fall out of sync and retreat.",
+                    "target": "saltglass_obelisk_east"
+                }
+            ]
+        },
+        "saltglass_glint_merge_ring": {
+            "title": "Triangulation Ring",
+            "text": "Three glint obelisks cast intersecting halos, a mirrored ring spinning fast enough to etch a permanent route.",
+            "choices": [
+                {
+                    "text": "(Cartographer) Seal the triangulation with the southern obelisk.",
+                    "condition": {
+                        "type": "flag_eq",
+                        "flag": "glint_obelisk_south_mapped",
+                        "value": true
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "glint_network_compiled",
+                            "value": true
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "treaty_ready",
+                            "value": true
+                        },
+                        {
+                            "type": "unlock_start",
+                            "value": "shade_walker_outpost"
+                        }
+                    ],
+                    "target": "saltglass_glint_merge_ring"
+                },
+                {
+                    "text": "Carry the completed map to the caravan council.",
+                    "condition": {
+                        "type": "flag_eq",
+                        "flag": "glint_network_compiled",
+                        "value": true
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "map_presented",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_carravan_council"
+                },
+                {
+                    "text": "Let the reflections dim and return to the dunes.",
+                    "target": "saltglass_expanse"
+                }
+            ]
+        },
+        "saltglass_treaty_alignment": {
+            "title": "Treaty Dais of Moving Shade",
+            "text": "Prism panels unfurl as your shade key slots into place, the walking city's shadow forming a parliament of light.",
+            "choices": [
+                {
+                    "text": "(Cartographer) Proclaim the Treaty of Moving Shade.",
+                    "condition": {
+                        "type": "flag_eq",
+                        "flag": "treaty_ready",
+                        "value": true
+                    },
+                    "effects": [
+                        {
+                            "type": "remove_item",
+                            "value": "shade key"
+                        },
+                        {
+                            "type": "end_game",
+                            "value": "Treaty of Moving Shade"
+                        }
+                    ],
+                    "target": "ending_shade_treaty"
+                },
+                {
+                    "text": "(Tinkerer) Adjust the shade engine clamps for leverage.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Tinkerer"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "treaty_clamps_tuned",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_carravan_council"
+                },
+                {
+                    "text": "Step back to the caravan council with your findings.",
+                    "target": "saltglass_carravan_council"
+                }
+            ]
+        },
+        "mentor_glasswright_intro": {
+            "title": "Glasswright Kilnback",
+            "text": "A master glasswright rides a kiln-backed crawler, sketching shade lattices in hovering light.",
+            "choices": [
+                {
+                    "text": "(Tinkerer) Present your lattice sketches for critique.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Tinkerer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "glasswright_sketch",
+                            "value": true
+                        }
+                    ],
+                    "target": "mentor_glasswright_trial"
+                },
+                {
+                    "text": "(Cartographer) Show how you mapped the engine's ribs to guide the reefs.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "glasswright_chart",
+                            "value": true
+                        }
+                    ],
+                    "target": "mentor_glasswright_trial"
+                },
+                {
+                    "text": "Ask for guidance on balancing migrating shade.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "glasswright_patience",
+                            "value": true
+                        }
+                    ],
+                    "target": "mentor_glasswright_trial"
+                },
+                {
+                    "text": "Return to the shade workshop.",
+                    "target": "saltglass_shade_workshop"
+                }
+            ]
+        },
+        "mentor_glasswright_trial": {
+            "title": "Glasswright Trial Loom",
+            "text": "The mentor raises a lattice of heat and glass, expecting you to anchor the migrating shadows.",
+            "choices": [
+                {
+                    "text": "(Lumenar) Bend kiln-light to follow the mentor's pattern.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Lumenar"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "glasswright_light",
+                            "value": true
+                        }
+                    ],
+                    "target": "mentor_glasswright_award"
+                },
+                {
+                    "text": "(Tinkerer) Stitch a color baffle into the shade engine seam.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Tinkerer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "glasswright_baffle",
+                            "value": true
+                        },
+                        {
+                            "type": "add_item",
+                            "value": "color baffle"
+                        }
+                    ],
+                    "target": "mentor_glasswright_award"
+                },
+                {
+                    "text": "(Sneaky) Slip a map sliver under the lens to reveal hidden fractures.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Sneaky"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "glasswright_hidden",
+                            "value": true
+                        }
+                    ],
+                    "target": "mentor_glasswright_award"
+                },
+                {
+                    "text": "Admit you need more practice and return to the workshop.",
+                    "target": "saltglass_shade_workshop"
+                }
+            ]
+        },
+        "mentor_glasswright_award": {
+            "title": "Glasswright Accord",
+            "text": "Satisfied, the mentor traces a sigil of refracted light and offers a shard inscribed with your new calling.",
+            "choices": [
+                {
+                    "text": "Accept the lattice oath and become a Glasswright.",
+                    "condition": {
+                        "type": "flag_eq",
+                        "flag": "glasswright_light",
+                        "value": true
+                    },
+                    "effects": [
+                        {
+                            "type": "add_tag",
+                            "value": "Glasswright"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "glasswright_mentored",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_shade_workshop"
+                },
+                {
+                    "text": "(Tinkerer) Swear to tend the migratory shade engines.",
+                    "condition": {
+                        "type": "flag_eq",
+                        "flag": "glasswright_baffle",
+                        "value": true
+                    },
+                    "effects": [
+                        {
+                            "type": "add_tag",
+                            "value": "Glasswright"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "glasswright_mentored",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_shade_workshop"
+                },
+                {
+                    "text": "(Sneaky) Promise to guard the hidden fractures of the reefs.",
+                    "condition": {
+                        "type": "flag_eq",
+                        "flag": "glasswright_hidden",
+                        "value": true
+                    },
+                    "effects": [
+                        {
+                            "type": "add_tag",
+                            "value": "Glasswright"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "glasswright_mentored",
+                            "value": true
+                        }
+                    ],
+                    "target": "saltglass_shade_workshop"
+                },
+                {
+                    "text": "Thank the mentor and step back into the workshop.",
+                    "target": "saltglass_shade_workshop"
+                }
+            ]
+        },
+        "ending_shade_treaty": {
+            "title": "Treaty of Moving Shade",
+            "text": "Walking cities align their shadows across the dunes as caravans salute your accord, mirrored dunes humming with newfound law."
         }
     }
 }


### PR DESCRIPTION
## Summary
- add the Saltglass Expanse hub with twelve interconnected nodes, a new short ending, and the Glasswright mentor arc
- wire the hub into the existing progression with a Shade-Walker Outpost start unlock and new Travel option from the Caretaker Dais
- update the validator so unlock_start effects are treated as valid content

## Testing
- python3 tools/validate.py

------
https://chatgpt.com/codex/tasks/task_e_68d3db0c0d288326b5bd1ff8b6c04575