### PR TITLE
Add Starfallen Orchard hub with Story-Graft trait

### DIFF
--- a/world/world.json
+++ b/world/world.json
@@ -109,6 +109,17 @@
                 "Lumenar"
             ],
             "locked": true
+        },
+        {
+            "id": "orchard_keeper_hut",
+            "title": "Orchard Keeper's Hut",
+            "locked_title": "Orchard Keeper's Hut (Locked)",
+            "node": "orchard_keeper_hut",
+            "tags": [
+                "Resonant",
+                "Cartographer"
+            ],
+            "locked": true
         }
     ],
     "endings": {
@@ -117,7 +128,8 @@
         "ending_correction": "You become the seasonal caretaker of the orrery.",
         "ending_unshattered_gale": "You harmonize the Cloud-Burrow updrafts into a lasting gale.",
         "ending_living_wake": "You inaugurate a civic wake that redraws how travelers depart.",
-        "ending_amnesty_of_names": "You usher in an amnesty that lets every traveler reclaim or reinvent the names they need."
+        "ending_amnesty_of_names": "You usher in an amnesty that lets every traveler reclaim or reinvent the names they need.",
+        "ending_sharecrop_of_stories": "You cultivate a public memory commons where every grafted fruit yields stories for all."
     },
     "nodes": {
         "sky_docks": {
@@ -2145,6 +2157,17 @@
                         }
                     ],
                     "target": "saltglass_carravan_council"
+                },
+                {
+                    "text": "Trail the memory-laden caravan toward the Starfallen Orchard.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_path_known",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_meteoric_gate"
                 },
                 {
                     "text": "Follow the tuned root-paths back to the Caretaker Dais.",
@@ -5528,6 +5551,653 @@
                     "target": "shed_market_cocoon_hostel"
                 }
             ]
+        },
+        "orchard_keeper_hut": {
+            "title": "Orchard Keeper's Hut",
+            "text": "Meteor-fruit hang from rafters like lanterns, each pulsing with whispers of seasons past. Ledger-boards and grafting tools crowd the hut, inviting you to steward the memories stored here.",
+            "choices": [
+                {
+                    "text": "(Resonant) Hum with the rafters until the stored fruit echo your pitch.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Resonant"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_resonance_grove"
+                },
+                {
+                    "text": "(Cartographer) Study the pinned root-maps to plot the ripest rows.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_map_shared",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_cartography_canopy"
+                },
+                {
+                    "text": "Step outside into the meteoric grove.",
+                    "target": "starfallen_orchard_meteoric_gate"
+                },
+                {
+                    "text": "Offer to log today's gleanings for the sharecrop commons.",
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_sharecrop_commons"
+                }
+            ]
+        },
+        "starfallen_orchard_meteoric_gate": {
+            "title": "Meteoric Gate",
+            "text": "Meteor-split trunks arch overhead, humming as orchardists check ledgers hung from branches. Dew that remembers every footfall beads along the path ahead.",
+            "choices": [
+                {
+                    "text": "(Resonant) Trade chords with the gatekeeper to align the grove's pulse.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Resonant"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_resonance_grove"
+                },
+                {
+                    "text": "(Cartographer) Trace the meteor scars to orient the next harvest rows.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_gate_surveyed",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_cartography_canopy"
+                },
+                {
+                    "text": "Shadow the orchardists toward the echo press hall.",
+                    "target": "starfallen_orchard_echo_press"
+                },
+                {
+                    "text": "Peel away along the saltglass trade path.",
+                    "target": "saltglass_expanse"
+                }
+            ]
+        },
+        "starfallen_orchard_echo_press": {
+            "title": "Echo Press Hall",
+            "text": "Copper presses squeeze starlit juice into memory flasks while archivists whisper transcripts. The air tastes of resin and rain recalled from distant harvests.",
+            "choices": [
+                {
+                    "text": "Help catalogue the jars of remembered rain.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_commons_ready",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_memory_rows"
+                },
+                {
+                    "text": "(Glasswright) Recalibrate the prismatic decanters to catch stray memories.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Glasswright"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_glass_lattice"
+                },
+                {
+                    "text": "(Healer) Massage sap-weary hands with meteor balm.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Healer"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Root Assembly",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_healer_bower"
+                },
+                {
+                    "text": "(Favor) Trade a favor for a private memory graft.",
+                    "condition": {
+                        "type": "has_item",
+                        "value": "favor"
+                    },
+                    "effects": [
+                        {
+                            "type": "remove_item",
+                            "value": "favor"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_private_spool",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_story_graft"
+                }
+            ]
+        },
+        "starfallen_orchard_memory_rows": {
+            "title": "Memory Rows",
+            "text": "Rows of luminous fruit sway with chimes of stored voices, each branch etched with meteor glass tallies. Orchardists nod as you pass, their satchels heavy with stories owed.",
+            "choices": [
+                {
+                    "text": "Follow the furrow toward the meteor cradle.",
+                    "target": "starfallen_orchard_meteor_cradle"
+                },
+                {
+                    "text": "(Cartographer) Note the resonance lines and update your root map.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_map_shared",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_cartography_canopy"
+                },
+                {
+                    "text": "(Resonant) Lead a lullaby to settle the most burdened branches.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Resonant"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_resonance_grove"
+                },
+                {
+                    "text": "Gather shared fruit for the coming commons.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_commons_ready",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_sharecrop_commons"
+                }
+            ]
+        },
+        "starfallen_orchard_meteor_cradle": {
+            "title": "Meteor Cradle",
+            "text": "At the crater's heart, meteoric stone cradles saplings whose skins shimmer with falling starlight. Warmth rolls from the pit, smelling of ozone and fresh parchment.",
+            "choices": [
+                {
+                    "text": "(Glasswright) Shape fused rind into lattice keys for the archive.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Glasswright"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_glass_lattice"
+                },
+                {
+                    "text": "(Healer) Draw the meteor warmth to ease orchardists' joints.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Healer"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Root Assembly",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_healer_bower"
+                },
+                {
+                    "text": "Collect fallen starfruit to feed the commons kettle.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_commons_ready",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_sharecrop_commons"
+                },
+                {
+                    "text": "Circle back toward the meteoric gate.",
+                    "target": "starfallen_orchard_meteoric_gate"
+                }
+            ]
+        },
+        "starfallen_orchard_resonance_grove": {
+            "title": "Resonance Grove",
+            "text": "Suspended chimes and taut vines resonate with distant thunder, carrying the grove's memory-song. Orchardists rest beneath the hum, cupping fruit to catch each echo.",
+            "choices": [
+                {
+                    "text": "(Resonant) Thread your chord through the grove's chorus.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Resonant"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_story_graft"
+                },
+                {
+                    "text": "(Healer) Sync breath with the tenders to steady their pulse.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Healer"
+                    },
+                    "effects": [
+                        {
+                            "type": "hp_delta",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_healer_bower"
+                },
+                {
+                    "text": "Carry the bottled chord toward the sharecrop fire.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_commons_ready",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_sharecrop_commons"
+                },
+                {
+                    "text": "Slip back through the listening rows.",
+                    "target": "starfallen_orchard_memory_rows"
+                }
+            ]
+        },
+        "starfallen_orchard_cartography_canopy": {
+            "title": "Cartography Canopy",
+            "text": "A lattice of ladders and meteor glass platforms reveals the grove's constellated rows. From here the orchard unfurls like a star map anchored in soil.",
+            "choices": [
+                {
+                    "text": "(Cartographer) Chart the shifting root constellations for the ledgers.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_story_graft"
+                },
+                {
+                    "text": "(Glasswright) Embed prisms to catch new paths of light.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Glasswright"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Prism Cartel",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_glass_lattice"
+                },
+                {
+                    "text": "Signal your findings down to the commons crew.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_commons_ready",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_sharecrop_commons"
+                },
+                {
+                    "text": "Descend to the meteoric gate.",
+                    "target": "starfallen_orchard_meteoric_gate"
+                }
+            ]
+        },
+        "starfallen_orchard_healer_bower": {
+            "title": "Healer's Bower",
+            "text": "Curtains of woven vine enclose tables of infusions where orchardists trade breath and pulse. Meteor-steamed basins glow softly, ready to ease overworked hands.",
+            "choices": [
+                {
+                    "text": "(Healer) Distill balm that keeps grafts from scarring.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Healer"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Root Assembly",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_story_graft"
+                },
+                {
+                    "text": "(Resonant) Hum counterpoints to soothe the resting archivists.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Resonant"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_resonance_grove"
+                },
+                {
+                    "text": "Take a restorative draught and rejoin the rows.",
+                    "effects": [
+                        {
+                            "type": "hp_delta",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_memory_rows"
+                },
+                {
+                    "text": "Deliver cooled balms to the sharecrop table.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_commons_ready",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_sharecrop_commons"
+                }
+            ]
+        },
+        "starfallen_orchard_glass_lattice": {
+            "title": "Glass Lattice Loom",
+            "text": "Glass threads stretch between meteor stakes, each strand shimmering with captured recollections. Apprentices etch glyphs into the lattice to guide future harvests.",
+            "choices": [
+                {
+                    "text": "(Glasswright) Tune the capillaries so memories flow evenly.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Glasswright"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_story_graft"
+                },
+                {
+                    "text": "(Cartographer) Weave a star-path into the lattice for future pickers.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_map_shared",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_cartography_canopy"
+                },
+                {
+                    "text": "Archive a gleaming story for the commons jars.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_commons_ready",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_sharecrop_commons"
+                },
+                {
+                    "text": "Follow cooling troughs back to the meteor cradle.",
+                    "target": "starfallen_orchard_meteor_cradle"
+                }
+            ]
+        },
+        "starfallen_orchard_story_graft": {
+            "title": "Story-Graft Arbor",
+            "text": "A living arbor waits with a hollow branch, ready to accept a sliver of your true name. Orchard keepers steady the grafting knives, eyes bright with the promise of shared memory.",
+            "choices": [
+                {
+                    "text": "Plant a graft bearing your true name and share its charge.",
+                    "condition": {
+                        "type": "flag_eq",
+                        "flag": "story_graft_taken",
+                        "value": false
+                    },
+                    "effects": [
+                        {
+                            "type": "add_trait",
+                            "value": "Story-Graft"
+                        },
+                        {
+                            "type": "add_item",
+                            "value": "story_graft_charge"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "story_graft_taken",
+                            "value": true
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_true_name_planted",
+                            "value": true
+                        },
+                        {
+                            "type": "unlock_start",
+                            "value": "orchard_keeper_hut"
+                        },
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_graft_recovery"
+                },
+                {
+                    "text": "Trace the new graft's pulse and promise to return.",
+                    "condition": {
+                        "type": "flag_eq",
+                        "flag": "story_graft_taken",
+                        "value": true
+                    },
+                    "target": "starfallen_orchard_memory_rows"
+                },
+                {
+                    "text": "Step away before the branch can claim you.",
+                    "target": "starfallen_orchard_memory_rows"
+                }
+            ]
+        },
+        "starfallen_orchard_graft_recovery": {
+            "title": "Graft Recovery Alcove",
+            "text": "Lanternfruit dim to a gentle glow as keepers bandage your new graft, weaving its pulse into yours. Cooling vapors and annotated ledgers surround a circle of resting orchardists.",
+            "choices": [
+                {
+                    "text": "(Story-Graft) Borrow a memory about the commons steward to guide your next move.",
+                    "condition": {
+                        "type": "has_item",
+                        "value": "story_graft_charge"
+                    },
+                    "effects": [
+                        {
+                            "type": "remove_item",
+                            "value": "story_graft_charge"
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "story_graft_borrowed",
+                            "value": true
+                        },
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_sharecrop_commons"
+                },
+                {
+                    "text": "(Cartographer) Compare your new graft lines with the grove's star-map.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_map_shared",
+                            "value": true
+                        }
+                    ],
+                    "target": "starfallen_orchard_cartography_canopy"
+                },
+                {
+                    "text": "(Healer) Check the graft for safe circulation.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Healer"
+                    },
+                    "effects": [
+                        {
+                            "type": "hp_delta",
+                            "value": 1
+                        }
+                    ],
+                    "target": "starfallen_orchard_healer_bower"
+                },
+                {
+                    "text": "Carry your renewed resolve to the commons.",
+                    "target": "starfallen_orchard_sharecrop_commons"
+                }
+            ]
+        },
+        "starfallen_orchard_sharecrop_commons": {
+            "title": "Sharecrop Commons",
+            "text": "A ring of tables laden with memory fruit forms the Sharecrop, each offering labeled for public use. Neighbors and travelers arrive in turn, ready to plant and borrow stories in trust.",
+            "choices": [
+                {
+                    "text": "Contribute your gathered fruit to inaugurate the commons.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "orchard_commons_ready",
+                            "value": true
+                        }
+                    ],
+                    "target": "ending_sharecrop_of_stories"
+                },
+                {
+                    "text": "(Resonant) Lead a broadcast so every graft echoes the invitation.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Resonant"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "ending_sharecrop_of_stories"
+                },
+                {
+                    "text": "(Cartographer) Plot rotation schedules to keep the commons balanced.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Cartographer"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Root Assembly",
+                            "value": 1
+                        }
+                    ],
+                    "target": "ending_sharecrop_of_stories"
+                },
+                {
+                    "text": "Slip away toward the saltglass expanse with new recollections.",
+                    "target": "saltglass_expanse"
+                }
+            ]
+        },
+        "ending_sharecrop_of_stories": {
+            "title": "The Sharecrop of Stories",
+            "text": "You open the orchard's ledgers to all comers, each graft a public promise that memories will be planted, tended, and shared in common."
         },
         "ending_amnesty_of_names": {
             "title": "Amnesty of Names",


### PR DESCRIPTION
## Summary
- add the Starfallen Orchard node set with 12 new scenes keyed to Resonant, Cartographer, Healer, and Glasswright play
- introduce the Story-Graft trait with a once-per-run memory borrowing branch and unlockable Orchard Keeper start
- wire in the Sharecrop of Stories medium ending plus a travel route from the Saltglass Expanse into the new hub

## Testing
- python tools/validate.py

------
https://chatgpt.com/codex/tasks/task_e_68d435bac46883268b2460d9bb68fcb2