### PR TITLE
Add sensory and accessibility polish to key hubs

### DIFF
--- a/world/world.json
+++ b/world/world.json
@@ -1067,7 +1067,7 @@
         },
         "root_orrery_registry": {
             "title": "Root Registry Tiers",
-            "text": "Bronze scribes stamp living writs while roots weave into counting frames; petitions rustle like leaves awaiting signature.",
+            "text": "Brass-sheathed root clerks hum from loam-caked abaci, stamping living writs; one pulses through your palm, 'We feel urgency by soil-scent—steady yourself.'",
             "choices": [
                 {
                     "text": "(Archivist) Compile the seasonal casework into a formal root-writ.",
@@ -1175,7 +1175,15 @@
                     "target": "root_orrery_resonance"
                 },
                 {
-                    "text": "Ask for a caretaker introduction.",
+                    "text": "Sign for a caretaker introduction while voicing your case.",
+                    "target": "root_orrery_mentor"
+                },
+                {
+                    "text": "(Resonant) Sign root-chords requesting a caretaker introduction.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Resonant"
+                    },
                     "target": "root_orrery_mentor"
                 },
                 {
@@ -4577,7 +4585,7 @@
         },
         "cloud_burrow_loft": {
             "title": "Cloud-Burrow Loft",
-            "text": "A reclaimed glider loft cradles the burrow family, hammocks swaying beside windbone chimes tuned to the gale.",
+            "text": "Ozone tang frays the fluff-swaddled hammocks; a wind-mole steward sniffs, 'Updraft tastes wary,' while glider bones sing along the gale-tuned chimes.",
             "choices": [
                 {
                     "text": "Glide down to the inverted plaza.",
@@ -4599,7 +4607,7 @@
                     "target": "cloud_burrow_tunnel_survey"
                 },
                 {
-                    "text": "(Resonant) Practice harmonies with the wind-mole chorus.",
+                    "text": "(Resonant) Sign-chime harmonies with the wind-mole chorus.",
                     "condition": {
                         "type": "has_tag",
                         "value": "Resonant"
@@ -5542,10 +5550,30 @@
         },
         "amber_tides_memory_vigil": {
             "title": "Memory Vigil",
-            "text": "Amber-lit alcoves hold sleepers sharing borrowed memories, their breaths syncing with a soft tide hymn.",
+            "text": "Resin candles bead across salt-slick ledger stones cradling borrowed memories; one stone murmurs in tide-signs, 'Hold us gently while we recall you.'",
             "choices": [
                 {
                     "text": "Guide the vigil toward the Living Wake preparations.",
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "amber_memory_vigil",
+                            "value": true
+                        }
+                    ],
+                    "target": "amber_tides_current_court"
+                },
+                {
+                    "text": "(Resonant) Sign-sway the ledger stone lullaby toward the Living Wake.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Resonant"
+                    },
                     "effects": [
                         {
                             "type": "rep_delta",


### PR DESCRIPTION
## Summary
- Refresh the Root Registry description with a root-clerk perspective and add a Resonant signing option when requesting introductions.
- Infuse the Cloud-Burrow loft scene with ozone-and-fluff sensory cues and revise its Resonant action to emphasize signing.
- Enrich the Memory Vigil with resin-and-salt imagery, plus a new Resonant signing path that advances the wake preparations.

## Testing
- python3 engine/engine_min.py (Root-Speaker path)
- python3 engine/engine_min.py (Cartographer path)
- python3 engine/engine_min.py (Tinkerer path)
- python3 engine/engine_min.py (Dreamwalker path)
- python3 engine/engine_min.py (Storm-Conductor path)
- python3 engine/engine_min.py (Tide-Singer path)


------
https://chatgpt.com/codex/tasks/task_e_68d455b7f4c483269f691064a0c49660