### PR TITLE
Add tagless Startways Nexus trials and align Storm Rail tags

### DIFF
--- a/world/world.json
+++ b/world/world.json
@@ -61,7 +61,7 @@
             "locked_title": "Storm Rail Mooring (Locked)",
             "node": "storm_rail_intro",
             "tags": [
-                "Scout",
+                "Cartographer",
                 "Resonant"
             ],
             "locked": true
@@ -2287,6 +2287,17 @@
                     "target": "nexus_moon_eel_reward"
                 },
                 {
+                    "text": "Match your breath to the tide and step through as it ebbs.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "moon_eel_ebbed",
+                            "value": true
+                        }
+                    ],
+                    "target": "nexus_moon_eel_reward"
+                },
+                {
                     "text": "Let the arch settle and step back toward the compass.",
                     "target": "startways_nexus"
                 }
@@ -2332,15 +2343,26 @@
                     "target": "nexus_storm_reward"
                 },
                 {
-                    "text": "(Scout) Chart the gust vectors and leap when the gale dips.",
+                    "text": "(Cartographer) Plot the gust vectors and stride in their lee.",
                     "condition": {
                         "type": "has_tag",
-                        "value": "Scout"
+                        "value": "Cartographer"
                     },
                     "effects": [
                         {
                             "type": "set_flag",
                             "flag": "storm_rail_mapped",
+                            "value": true
+                        }
+                    ],
+                    "target": "nexus_storm_reward"
+                },
+                {
+                    "text": "Brace against the railing and edge forward between surges.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "storm_rail_braced",
                             "value": true
                         }
                     ],


### PR DESCRIPTION
## Summary
- add tagless completion options to the Moon-Eel and Storm-Rail trials in the Startways Nexus
- align the Storm Rail starting tags with its cartographic focus

## Testing
- python tools/validate.py

------
https://chatgpt.com/codex/tasks/task_e_68d605689c108326bc947559b202deb5