### PR TITLE
Align Saltglass Expanse gating with core tags

### DIFF
--- a/world/world.json
+++ b/world/world.json
@@ -13,6 +13,7 @@
         "Tinkerer",
         "Trickster",
         "Lumenar",
+        "Glasswright",
         "Dreamwalker",
         "Storm-Conductor"
     ],
@@ -2349,10 +2350,10 @@
                     "target": "saltglass_obelisk_south"
                 },
                 {
-                    "text": "(Weaver) Stitch mirrored dune veils to reveal the buried orrery route.",
+                    "text": "(Lumenar) Refract the dunes' glare to reveal the buried orrery route.",
                     "condition": {
                         "type": "has_tag",
-                        "value": "Weaver"
+                        "value": "Lumenar"
                     },
                     "effects": [
                         {
@@ -2364,10 +2365,10 @@
                     "target": "root_orrery_threading"
                 },
                 {
-                    "text": "(Emissary) Convene caravan envoys for a guest-law audience at the dais.",
+                    "text": "(Tinkerer) Tune the envoy dais so caravan speakers can gather.",
                     "condition": {
                         "type": "has_tag",
-                        "value": "Emissary"
+                        "value": "Tinkerer"
                     },
                     "effects": [
                         {
@@ -2384,10 +2385,10 @@
                     "target": "guestlaw_chamber"
                 },
                 {
-                    "text": "(Emissary) Negotiate Aeol outriders for a direct Startways flight.",
+                    "text": "(Lumenar) Signal Aeol outriders for a direct Startways flight.",
                     "condition": {
                         "type": "has_tag",
-                        "value": "Emissary"
+                        "value": "Lumenar"
                     },
                     "effects": [
                         {
@@ -2586,12 +2587,12 @@
                     "target": "saltglass_glass_reef"
                 },
                 {
-                    "text": "(Sneaky+Resonant) Slip into the echo-market to chart contraband song routes.",
+                    "text": "(Sneaky+Lumenar) Diffuse the echo-market's glare to chart contraband routes.",
                     "condition": {
                         "type": "has_tag",
                         "value": [
                             "Sneaky",
-                            "Resonant"
+                            "Lumenar"
                         ]
                     },
                     "effects": [
@@ -2622,11 +2623,11 @@
                     "target": "saltglass_prism_cache"
                 },
                 {
-                    "text": "(Scout+Tinkerer) Retrofit a glider harness to surf the shade thermals.",
+                    "text": "(Lumenar+Tinkerer) Retrofit a glider harness to surf the shade thermals.",
                     "condition": {
                         "type": "has_tag",
                         "value": [
-                            "Scout",
+                            "Lumenar",
                             "Tinkerer"
                         ]
                     },


### PR DESCRIPTION
## Summary
- add the Glasswright tag to the advanced tag roster so the mentor reward is tracked
- retune Saltglass Expanse entry options to rely on the hub's Cartographer, Tinkerer, Lumenar, and Sneaky focus
- adjust Shade Engine Bazaar combination gates to the same core tag set

## Testing
- python tools/validate.py

------
https://chatgpt.com/codex/tasks/task_e_68d60cb80a2c832689c58ee213d6f82a