### PR TITLE
Add signway relay path and mediation to Cloud-Burrow hub

### DIFF
--- a/world/world.json
+++ b/world/world.json
@@ -4010,6 +4010,17 @@
                     "target": "cloud_burrow_guest_ledger"
                 },
                 {
+                    "text": "Follow the wind-hand interpreters toward the signway balcony.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "windhands_relay",
+                            "value": true
+                        }
+                    ],
+                    "target": "cloud_burrow_signway_balcony"
+                },
+                {
                     "text": "Thank the family and descend toward the threshold.",
                     "target": "cloud_burrow_threshold"
                 }
@@ -4057,6 +4068,21 @@
                         }
                     ],
                     "target": "cloud_burrow_updraft_well"
+                },
+                {
+                    "text": "(Resonant) Sign the wind-hand cant with the well tenders and plan a silent relay.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Resonant"
+                    },
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "windhands_relay",
+                            "value": true
+                        }
+                    ],
+                    "target": "cloud_burrow_signway_balcony"
                 },
                 {
                     "text": "(Healer) Ease the wind-tenders' ringing ears with cooling salves.",
@@ -4154,6 +4180,36 @@
                     "target": "cloud_burrow_resonant_wells"
                 },
                 {
+                    "text": "(Arbiter) Convene a signed gust moot so every burrow shares the breeze fairly.",
+                    "condition": {
+                        "type": "has_tag",
+                        "value": "Arbiter"
+                    },
+                    "effects": [
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "windhands_relay",
+                            "value": true
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "windhands_moot_calm",
+                            "value": true
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "windhands_balcony_synced",
+                            "value": true
+                        }
+                    ],
+                    "target": "cloud_burrow_signway_forum"
+                },
+                {
                     "text": "Carry gust petitions back to the embassy clerks.",
                     "effects": [
                         {
@@ -4187,7 +4243,7 @@
                     "target": "cloud_burrow_threshold"
                 },
                 {
-                    "text": "(Resonant) Join the market chorus to steady the inverted stalls.",
+                    "text": "(Resonant) Sign along with the market chorus to steady the inverted stalls.",
                     "condition": {
                         "type": "has_tag",
                         "value": "Resonant"
@@ -4235,6 +4291,145 @@
                         }
                     ],
                     "target": "cloud_burrow_mole_warren"
+                }
+            ]
+        },
+        "cloud_burrow_signway_balcony": {
+            "title": "Signway Balcony",
+            "text": "Harness lines cradle a quiet overlook where wind-mole interpreters trade gust-hand signs while lanterns dim to carry silent messages.",
+            "choices": [
+                {
+                    "text": "(Resonant) Flash the wind-hand greetings and sync your pulse to their silent count.",
+                    "condition": [
+                        {
+                            "type": "has_tag",
+                            "value": "Resonant"
+                        },
+                        {
+                            "type": "flag_eq",
+                            "flag": "windhands_relay",
+                            "value": true
+                        }
+                    ],
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "windhands_balcony_synced",
+                            "value": true
+                        }
+                    ],
+                    "target": "cloud_burrow_signway_forum"
+                },
+                {
+                    "text": "Borrow a gust-slate to sketch your reply for the interpreters.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "windhands_balcony_synced",
+                            "value": true
+                        }
+                    ],
+                    "target": "cloud_burrow_signway_forum"
+                },
+                {
+                    "text": "Climb back toward the burrow balconies.",
+                    "target": "cloud_burrow_balcony_warrens"
+                }
+            ]
+        },
+        "cloud_burrow_signway_forum": {
+            "title": "Signed Gust Moot",
+            "text": "Community representatives circle a suspended ledger, palms flickering in gust-hand phrases to balance passage lanes.",
+            "choices": [
+                {
+                    "text": "(Resonant) Lead a silent compromise so every burrow receives the breeze it needs.",
+                    "condition": [
+                        {
+                            "type": "has_tag",
+                            "value": "Resonant"
+                        },
+                        {
+                            "type": "flag_eq",
+                            "flag": "windhands_balcony_synced",
+                            "value": true
+                        }
+                    ],
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "windhands_moot_calm",
+                            "value": true
+                        },
+                        {
+                            "type": "rep_delta",
+                            "faction": "Quiet Ledger",
+                            "value": 1
+                        }
+                    ],
+                    "target": "cloud_burrow_signway_well"
+                },
+                {
+                    "text": "Take notes on a ribbon-slate and pass them between the negotiators.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "windhands_moot_calm",
+                            "value": true
+                        }
+                    ],
+                    "target": "cloud_burrow_signway_well"
+                },
+                {
+                    "text": "Return the petitions to the windbone forum.",
+                    "target": "cloud_burrow_windbone_forum"
+                }
+            ]
+        },
+        "cloud_burrow_signway_well": {
+            "title": "Silent Updraft Brace",
+            "text": "Luminous cords sway beside the updraft well, each gesture translating into soft pulses that calm the gale.",
+            "choices": [
+                {
+                    "text": "(Resonant) Sign the gale-lattice into harmony and teach the watchers the pattern.",
+                    "condition": [
+                        {
+                            "type": "has_tag",
+                            "value": "Resonant"
+                        },
+                        {
+                            "type": "flag_eq",
+                            "flag": "windhands_moot_calm",
+                            "value": true
+                        }
+                    ],
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "gale_harmonics_ready",
+                            "value": true
+                        },
+                        {
+                            "type": "set_flag",
+                            "flag": "windhands_path_complete",
+                            "value": true
+                        }
+                    ],
+                    "target": "cloud_burrow_updraft_well"
+                },
+                {
+                    "text": "Hang lantern cues so anyone can follow the new silent counts.",
+                    "effects": [
+                        {
+                            "type": "set_flag",
+                            "flag": "windhands_path_complete",
+                            "value": true
+                        }
+                    ],
+                    "target": "cloud_burrow_updraft_well"
+                },
+                {
+                    "text": "Glide back toward the resonance wells.",
+                    "target": "cloud_burrow_resonant_wells"
                 }
             ]
         },


### PR DESCRIPTION
## Summary
- add a sign-language relay through new signway balcony, moot, and well nodes that culminate in the Unshattered Gale setup
- update Cloud-Burrow entry points with signway access for Resonant and tagless routes, including an Arbiter-led community mediation scene
- highlight the hub's signing culture by refreshing relevant choices such as the market chorus

## Testing
- python tools/validate.py

------
https://chatgpt.com/codex/tasks/task_e_68d61664c14083268c6f3263cdf92c44