### PR TITLE
Add Rememberer's Boon alternate wake branch

### DIFF
--- a/docs/world_bible.md
+++ b/docs/world_bible.md
@@ -41,6 +41,7 @@ Reserve 6 late-game upgrade tags; do not use or reference them yet.
 - **People-Reader** — Authors include one hidden branch per hub visible only with this trait; use for social insight or extra intel.
 - **Light-Step** — Provide an alternate branch that bypasses the first tag gate encountered in a hub. It should read as agile improvisation, not teleportation.
 - **Well-Provisioned** — Grants access to supply caches. Characters with the trait should reliably acquire or refresh a `favor` item that can be spent on tagless routes.
+- **Rememberer's Boon** — Unlocks mirrored memories that let the character author an alternate branch of events once per chapter.
 
 Traits are earned diegetically through choices (no menus). When granting a trait, consider pairing it with a resource or flag that motivates future branches.
 

--- a/world/world.json
+++ b/world/world.json
@@ -6388,6 +6388,14 @@
                     "target": "amber_tides_funeral_armada"
                 },
                 {
+                    "text": "(Rememberer's Boon) Recall a mirrored wake chapter to host late arrivals without breaking the rite.",
+                    "condition": {
+                        "type": "has_trait",
+                        "value": "Rememberer's Boon"
+                    },
+                    "target": "amber_tides_mnemonic_harbor"
+                },
+                {
                     "text": "Lead the Living Wake, inviting travelers to depart within the rite itself.",
                     "condition": {
                         "type": "flag_eq",


### PR DESCRIPTION
## Summary
- add a Rememberer's Boon-gated choice to the Amber Tides wake processional
- document the Rememberer's Boon trait guidance in the world bible

## Testing
- python tools/validate.py

------
https://chatgpt.com/codex/tasks/task_e_68d6183dca8c8326ae2fae0d9e483ae6