### PR TITLE
Align Starfallen Orchard synergy and Story-Graft flow

### DIFF
--- a/world/world.json
+++ b/world/world.json
@@ -8299,12 +8299,12 @@
                     "target": "starfallen_orchard_cartography_canopy"
                 },
                 {
-                    "text": "(Resonant+Cartographer) Overlay songlines and root maps to open a harmonic passage.",
+                    "text": "(Cartographer+Glasswright) Align mirrored root maps to open a harmonic passage.",
                     "condition": {
                         "type": "has_tag",
                         "value": [
-                            "Resonant",
-                            "Cartographer"
+                            "Cartographer",
+                            "Glasswright"
                         ]
                     },
                     "effects": [
@@ -9024,6 +9024,11 @@
                         },
                         {
                             "type": "set_flag",
+                            "flag": "story_graft_borrowed",
+                            "value": false
+                        },
+                        {
+                            "type": "set_flag",
                             "flag": "orchard_true_name_planted",
                             "value": true
                         },
@@ -9059,11 +9064,22 @@
             "text": "Lanternfruit dim to a gentle glow as keepers bandage your new graft, weaving its pulse into yours. Cooling vapors and annotated ledgers surround a circle of resting orchardists.",
             "choices": [
                 {
-                    "text": "(Story-Graft) Borrow a memory about the commons steward to guide your next move.",
-                    "condition": {
-                        "type": "has_item",
-                        "value": "story_graft_charge"
-                    },
+                    "text": "(Story-Graft) Spend your graft charge to borrow a memory about the commons steward.",
+                    "condition": [
+                        {
+                            "type": "has_trait",
+                            "value": "Story-Graft"
+                        },
+                        {
+                            "type": "has_item",
+                            "value": "story_graft_charge"
+                        },
+                        {
+                            "type": "flag_eq",
+                            "flag": "story_graft_borrowed",
+                            "value": false
+                        }
+                    ],
                     "effects": [
                         {
                             "type": "remove_item",


### PR DESCRIPTION
## Summary
- require the Starfallen Orchard harmonic passage to be opened with the Cartographer+Glasswright synergy
- reset the Story-Graft borrow flag when the graft is planted and gate the borrow branch behind the trait and charge

## Testing
- python -m json.tool world/world.json

------
https://chatgpt.com/codex/tasks/task_e_68d61b27619c8326baea9828812590f1